### PR TITLE
Upgrade connection_pool to 3.x

### DIFF
--- a/lib/redis_pool.rb
+++ b/lib/redis_pool.rb
@@ -4,7 +4,7 @@ class RedisPool
   BACKOFF_MAX = 5 # seconds
 
   def initialize(pool_options, redis_options)
-    @pool = ConnectionPool.new(pool_options) do
+    @pool = ConnectionPool.new(**pool_options) do
       ::Redis.new(redis_options)
     end
     @failure_count = 0

--- a/lib/redis_pool.rb
+++ b/lib/redis_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RedisPool
   MAX_RETRIES = 3
   BACKOFF_BASE = 0.5 # seconds
@@ -17,9 +19,8 @@ class RedisPool
     retries = 0
 
     @pool.with do |redis|
-      begin
-        yield(redis)
-      rescue RedisClient::FailoverError, RedisClient::CannotConnectError => e
+      yield(redis)
+    rescue RedisClient::FailoverError, RedisClient::CannotConnectError => e
         retries += 1
         if retries <= MAX_RETRIES
           warn "[RedisPool] Redis connection lost: #{e.class} #{e.message}. Reconnecting (attempt #{retries})..."
@@ -30,7 +31,6 @@ class RedisPool
           record_failure
           raise e
         end
-      end
     end
   rescue RedisClient::FailoverError, RedisClient::CannotConnectError => e
     record_failure

--- a/lib/rels_session.rb
+++ b/lib/rels_session.rb
@@ -62,7 +62,7 @@ module RelsSession
       SessionStore.sessions
     end
 
-    def stream_sessions(batch_size: scan_count=DEFAULT_SCAN_COUNT, stage: nil)
+    def stream_sessions(batch_size: scan_count = DEFAULT_SCAN_COUNT, stage: nil)
       raise ArgumentError, "block required" unless block_given?
 
       store = SessionStore.instance
@@ -75,6 +75,7 @@ module RelsSession
         payloads = redis.then { |r| r.mget(*keys) }
         payloads.each do |payload|
           next unless payload
+
           session_payload = serializer.load(payload)
           next if stage_filter && SessionIntrospection.stage(session_payload) != stage_filter
 

--- a/lib/rels_session/session_introspection.rb
+++ b/lib/rels_session/session_introspection.rb
@@ -3,7 +3,7 @@
 module RelsSession
   # Helpers to infer attributes from serialized session payloads.
   module SessionIntrospection
-    extend self
+    module_function
 
     STAGES = %i[anonymous authenticated in_course].freeze
     COURSE_KEYS = %i[course_id course_uuid].freeze

--- a/lib/rels_session/session_store.rb
+++ b/lib/rels_session/session_store.rb
@@ -107,7 +107,7 @@ module RelsSession
     end
 
     # Drop in session store for Reallyenglish rails apps.
-    def list_sessions(stream: false)
+    def list_sessions(stream: false, &block)
       pattern = "#{@namespace}:2::*"
 
       if stream
@@ -115,10 +115,11 @@ module RelsSession
 
         @redis.then do |r|
           cursor = "0"
-          begin
+          loop do
             cursor, keys = r.scan(cursor, match: pattern, count: RelsSession.scan_count)
-            keys.each { |key| yield key }
-          end while cursor != "0"
+            keys.each(&block)
+            break unless cursor != "0"
+          end
         end
         return
       end
@@ -126,10 +127,11 @@ module RelsSession
       sessions = []
       @redis.then do |r|
         cursor = "0"
-        begin
+        loop do
           cursor, keys = r.scan(cursor, match: pattern, count: RelsSession.scan_count)
           sessions.concat(keys)
-        end while cursor != "0"
+          break unless cursor != "0"
+        end
       end
       sessions
     end
@@ -179,19 +181,15 @@ module RelsSession
       cache_valid = @secure_store_cached_at &&
                     (Time.now - @secure_store_cached_at) < SECURE_STORE_CACHE_TTL
 
-      if cache_valid && !@secure_store_cached_value.nil?
-        return @secure_store_cached_value
-      end
+      return @secure_store_cached_value if cache_valid && !@secure_store_cached_value.nil?
 
       flag_key = secure_store_flag_key
 
-      unless use_private_id?
-        if secure_flag_write_due?
-          @redis.then do |r|
-            r.set(flag_key, Time.now.to_i, ex: SECURE_STORE_CACHE_TTL, nx: true)
-          end
-          @secure_store_flag_written_at = Time.now
+      if !use_private_id? && secure_flag_write_due?
+        @redis.then do |r|
+          r.set(flag_key, Time.now.to_i, ex: SECURE_STORE_CACHE_TTL, nx: true)
         end
+          @secure_store_flag_written_at = Time.now
       end
 
       cached_value = @redis.then { |r| r.exists?(flag_key) }

--- a/lib/rels_session/sessions_manager.rb
+++ b/lib/rels_session/sessions_manager.rb
@@ -204,6 +204,7 @@ module RelsSession
         if installation_id
           return "ios_app" if ios_device?(device, device_header)
           return "android_app" if android_device?(device, device_header)
+
           return "mobile_app"
         end
 
@@ -230,7 +231,6 @@ module RelsSession
         normalized = value.downcase
         needles.any? { |needle| normalized.include?(needle) }
       end
-
     end
   end
 end

--- a/lib/rels_session/stats.rb
+++ b/lib/rels_session/stats.rb
@@ -48,10 +48,11 @@ module RelsSession
 
       @redis.then do |r|
         cursor = "0"
-        begin
+        loop do
           cursor, keys = r.scan(cursor, match: pattern, count: RelsSession.scan_count)
           total_keys += keys.size
-        end while cursor != "0"
+          break unless cursor != "0"
+        end
 
         r.multi do |m|
           m.set(total_sessions_key, total_keys)

--- a/lib/rels_session/user_sessions.rb
+++ b/lib/rels_session/user_sessions.rb
@@ -3,7 +3,7 @@
 module RelsSession
   # Add and remove user sessions, outside of rails app. Used by session_store
   class UserSessions
-    def self.list(stream: false)
+    def self.list(stream: false, &block)
       pattern = "#{RelsSession.namespace}:user_sessions:*"
 
       if stream
@@ -11,10 +11,11 @@ module RelsSession
 
         RelsSession.redis.then do |r|
           cursor = "0"
-          begin
+          loop do
             cursor, keys = r.scan(cursor, match: pattern, count: RelsSession.scan_count)
-            keys.each { |key| yield key }
-          end while cursor != "0"
+            keys.each(&block)
+            break unless cursor != "0"
+          end
         end
         return
       end
@@ -22,10 +23,11 @@ module RelsSession
       sessions = []
       RelsSession.redis.then do |r|
         cursor = "0"
-        begin
+        loop do
           cursor, keys = r.scan(cursor, match: pattern, count: RelsSession.scan_count)
           sessions.concat(keys)
-        end while cursor != "0"
+          break unless cursor != "0"
+        end
       end
       sessions
     end

--- a/rels_session.gemspec
+++ b/rels_session.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "actionpack", ">= 7.0.2.4", "<= 9"
-  spec.add_runtime_dependency "connection_pool", ">= 2.2.5", "< 3"
+  spec.add_runtime_dependency "connection_pool", ">= 2.2.5", "< 4"
   spec.add_runtime_dependency "device_detector", ">= 1.0.7"
   spec.add_runtime_dependency "dry-schema", ">= 1.4.0"
   spec.add_runtime_dependency "dry-struct", ">= 1.4.0"

--- a/rels_session.gemspec
+++ b/rels_session.gemspec
@@ -28,20 +28,20 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "actionpack", ">= 7.0.2.4", "<= 9"
+  spec.add_runtime_dependency "base64"
+  spec.add_runtime_dependency "bigdecimal", ">= 3.0"
   spec.add_runtime_dependency "connection_pool", ">= 2.2.5", "< 4"
   spec.add_runtime_dependency "device_detector", ">= 1.0.7"
   spec.add_runtime_dependency "dry-schema", ">= 1.4.0"
   spec.add_runtime_dependency "dry-struct", ">= 1.4.0"
-  spec.add_runtime_dependency "bigdecimal", ">= 3.0"
   spec.add_runtime_dependency "mutex_m"
-  spec.add_runtime_dependency "base64"
   spec.add_runtime_dependency "oj", ">= 3.13"
   spec.add_runtime_dependency "redis", ">= 5", "< 6"
 
   spec.add_development_dependency "database_cleaner-redis"
+  spec.add_development_dependency "debug", "~> 1.11"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "debug", "~> 1.11"
   spec.add_development_dependency "rubocop", "~> 1.27"
   spec.add_development_dependency "rubocop-rake", "~> 0.6"
   spec.add_development_dependency "rubocop-rspec", "~> 2.8"

--- a/spec/redis_pool_spec.rb
+++ b/spec/redis_pool_spec.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
-# spec/redis_pool_spec.rb
-require "spec_helper" # or rails_helper if inside Rails
+require "spec_helper"
 require "redis"
-require_relative "../lib/redis_pool" # adjust path
+require_relative "../lib/redis_pool"
 
 RSpec.describe RedisPool do
   let(:pool_options) { { size: 2, timeout: 5 } }
   let(:redis_options) { { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") } }
   subject(:redis_pool) { described_class.new(pool_options, redis_options) }
+
+  describe "pool configuration" do
+    it "passes pool options to ConnectionPool" do
+      pool = redis_pool.instance_variable_get(:@pool)
+      expect(pool.size).to eq(2)
+    end
+  end
 
   describe "#with" do
     it "successfully sets and gets a key" do
@@ -42,6 +48,36 @@ RSpec.describe RedisPool do
       expect do
         redis_pool.with { |redis| redis.set("fail-test-key", "fail-value") }
       end.to raise_error(RedisClient::CannotConnectError)
+    end
+  end
+
+  describe "circuit breaker" do
+    it "stays open and rejects calls within the backoff window" do
+      allow_any_instance_of(Redis).to receive(:set).and_raise(RedisClient::CannotConnectError,
+                                                              "Simulated total failure")
+      allow_any_instance_of(RedisPool).to receive(:rand).and_return(0.1)
+
+      2.times do
+        expect { redis_pool.with { |redis| redis.set("key", "val") } }.to raise_error(RedisClient::CannotConnectError)
+      end
+
+      expect { redis_pool.with { |redis| redis.set("key", "val") } }.to raise_error(RuntimeError, /circuit open/)
+    end
+  end
+
+  describe "method delegation" do
+    it "delegates Redis commands through the pool via method_missing" do
+      redis_pool.set("delegated-key", "delegated-value")
+      expect(redis_pool.get("delegated-key")).to eq("delegated-value")
+    end
+
+    it "responds to Redis methods" do
+      expect(redis_pool).to respond_to(:set)
+      expect(redis_pool).to respond_to(:get)
+    end
+
+    it "does not respond to unknown methods" do
+      expect(redis_pool).not_to respond_to(:nonexistent_method)
     end
   end
 end

--- a/spec/redis_pool_spec.rb
+++ b/spec/redis_pool_spec.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
+
 # spec/redis_pool_spec.rb
-require 'spec_helper' # or rails_helper if inside Rails
-require 'redis'
-require_relative '../lib/redis_pool' # adjust path
+require "spec_helper" # or rails_helper if inside Rails
+require "redis"
+require_relative "../lib/redis_pool" # adjust path
 
 RSpec.describe RedisPool do
   let(:pool_options) { { size: 2, timeout: 5 } }
-  let(:redis_options) { { url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') } }
+  let(:redis_options) { { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") } }
   subject(:redis_pool) { described_class.new(pool_options, redis_options) }
 
   describe "#with" do
     it "successfully sets and gets a key" do
       redis_pool.with do |redis|
-        redis.set('test-key', 'test-value')
-        expect(redis.get('test-key')).to eq('test-value')
+        redis.set("test-key", "test-value")
+        expect(redis.get("test-key")).to eq("test-value")
       end
     end
 
@@ -28,17 +30,18 @@ RSpec.describe RedisPool do
 
       allow_any_instance_of(RedisPool).to receive(:rand).and_return(0.1)
 
-      expect {
-        redis_pool.with { |redis| redis.set('retry-test-key', 'retry-value') }
-      }.not_to raise_error
+      expect do
+        redis_pool.with { |redis| redis.set("retry-test-key", "retry-value") }
+      end.not_to raise_error
     end
 
     it "raises error after max retries exceeded" do
-      allow_any_instance_of(Redis).to receive(:set).and_raise(RedisClient::CannotConnectError, "Simulated total failure")
+      allow_any_instance_of(Redis).to receive(:set).and_raise(RedisClient::CannotConnectError,
+                                                              "Simulated total failure")
 
-      expect {
-        redis_pool.with { |redis| redis.set('fail-test-key', 'fail-value') }
-      }.to raise_error(RedisClient::CannotConnectError)
+      expect do
+        redis_pool.with { |redis| redis.set("fail-test-key", "fail-value") }
+      end.to raise_error(RedisClient::CannotConnectError)
     end
   end
 end

--- a/spec/rels_session/serializer_spec.rb
+++ b/spec/rels_session/serializer_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe RelsSession::Serializers do
+  describe ".for" do
+    it "returns a JsonSerializer for :json" do
+      expect(described_class.for(:json)).to be_a(RelsSession::Serializers::JsonSerializer)
+    end
+
+    it "returns an OjSerializer for :oj" do
+      expect(described_class.for(:oj)).to be_a(RelsSession::Serializers::OjSerializer)
+    end
+
+    it "accepts a string name" do
+      expect(described_class.for("json")).to be_a(RelsSession::Serializers::JsonSerializer)
+    end
+
+    it "raises ArgumentError for an unsupported serializer" do
+      expect { described_class.for(:yaml) }.to raise_error(ArgumentError, /Unsupported serializer/)
+    end
+  end
+
+  shared_examples "a serializer" do
+    let(:payload) { { "foo" => "bar", "num" => 42 } }
+
+    describe "#dump" do
+      it "serializes a hash to a string" do
+        result = serializer.dump(payload)
+        expect(result).to be_a(String)
+        expect(result).to include("bar")
+      end
+
+      it "handles nested hashes" do
+        nested = { "a" => { "b" => [1, 2] } }
+        result = serializer.dump(nested)
+        expect(result).to be_a(String)
+      end
+
+      it "handles empty hashes" do
+        expect(serializer.dump({})).to be_a(String)
+      end
+    end
+
+    describe "#load" do
+      it "deserializes a string to a hash" do
+        dumped = serializer.dump(payload)
+        expect(serializer.load(dumped)).to eq(payload)
+      end
+
+      it "round-trips complex data" do
+        complex = { "string" => "hello", "int" => 1, "float" => 1.5, "array" => [1, 2], "nested" => { "key" => "val" } }
+        expect(serializer.load(serializer.dump(complex))).to eq(complex)
+      end
+    end
+  end
+
+  describe RelsSession::Serializers::JsonSerializer do
+    let(:serializer) { described_class.new }
+    it_behaves_like "a serializer"
+  end
+
+  describe RelsSession::Serializers::OjSerializer do
+    let(:serializer) { described_class.new }
+    it_behaves_like "a serializer"
+  end
+end

--- a/spec/rels_session/session_introspection_spec.rb
+++ b/spec/rels_session/session_introspection_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+RSpec.describe RelsSession::SessionIntrospection do
+  describe ".normalize_stage" do
+    it "returns the symbol for :anonymous" do
+      expect(described_class.normalize_stage(:anonymous)).to eq(:anonymous)
+    end
+
+    it "returns the symbol for :authenticated" do
+      expect(described_class.normalize_stage(:authenticated)).to eq(:authenticated)
+    end
+
+    it "returns the symbol for :in_course" do
+      expect(described_class.normalize_stage(:in_course)).to eq(:in_course)
+    end
+
+    it "accepts a string" do
+      expect(described_class.normalize_stage("authenticated")).to eq(:authenticated)
+    end
+
+    it "raises ArgumentError for unknown stages" do
+      expect { described_class.normalize_stage(:bogus) }.to raise_error(ArgumentError, /Unknown session stage/)
+    end
+  end
+
+  describe ".stage" do
+    it "returns :anonymous for nil payload" do
+      expect(described_class.stage(nil)).to eq(:anonymous)
+    end
+
+    it "returns :anonymous for empty payload" do
+      expect(described_class.stage({})).to eq(:anonymous)
+    end
+
+    it "returns :authenticated when signed in without a course" do
+      payload = { "warden.user.user.key" => [[1], "salt"] }
+      expect(described_class.stage(payload)).to eq(:authenticated)
+    end
+
+    it "returns :in_course when signed in with a course_id" do
+      payload = { "warden.user.user.key" => [[1], "salt"], "course_id" => "42" }
+      expect(described_class.stage(payload)).to eq(:in_course)
+    end
+
+    it "returns :in_course when signed in with a course_uuid" do
+      payload = { "warden.user.user.key" => [[1], "salt"], "course_uuid" => "abc-def" }
+      expect(described_class.stage(payload)).to eq(:in_course)
+    end
+
+    it "finds course_id in meta sub-hash" do
+      payload = { "warden.user.user.key" => [[1], "salt"], "meta" => { "course_id" => "99" } }
+      expect(described_class.stage(payload)).to eq(:in_course)
+    end
+
+    it "uses symbol key for warden" do
+      payload = { "warden.user.user.key": [[1], "salt"] }
+      expect(described_class.stage(payload)).to eq(:authenticated)
+    end
+  end
+
+  describe ".course_id" do
+    it "returns nil for nil payload" do
+      expect(described_class.course_id(nil)).to be_nil
+    end
+
+    it "returns nil for empty payload" do
+      expect(described_class.course_id({})).to be_nil
+    end
+
+    it "returns the course_id from the top-level" do
+      expect(described_class.course_id({ "course_id" => "7" })).to eq("7")
+    end
+
+    it "returns the course_uuid from the top-level" do
+      expect(described_class.course_id({ "course_uuid" => "abc" })).to eq("abc")
+    end
+
+    it "prefers course_id over course_uuid" do
+      result = described_class.course_id({ "course_id" => "1", "course_uuid" => "2" })
+      expect(result).to eq("1")
+    end
+
+    it "returns course_id from meta sub-hash" do
+      payload = { "meta" => { "course_id" => "42" } }
+      expect(described_class.course_id(payload)).to eq("42")
+    end
+
+    it "returns nil when meta is not a hash" do
+      payload = { "meta" => "just a string" }
+      expect(described_class.course_id(payload)).to be_nil
+    end
+
+    it "handles symbol keys" do
+      expect(described_class.course_id({ course_id: "99" })).to eq("99")
+    end
+  end
+
+  describe ".signed_in?" do
+    it "returns false for nil payload" do
+      expect(described_class.signed_in?(nil)).to be false
+    end
+
+    it "returns false for empty payload" do
+      expect(described_class.signed_in?({})).to be false
+    end
+
+    it "returns true when warden.user.user.key is present (string key)" do
+      payload = { "warden.user.user.key" => [[1], "salt"] }
+      expect(described_class.signed_in?(payload)).to be true
+    end
+
+    it "returns true when warden.user.user.key is present (symbol key)" do
+      payload = { :"warden.user.user.key" => [[1], "salt"] }
+      expect(described_class.signed_in?(payload)).to be true
+    end
+
+    it "returns false when warden key is empty" do
+      payload = { "warden.user.user.key" => [] }
+      expect(described_class.signed_in?(payload)).to be false
+    end
+
+    it "returns false when warden key is nil" do
+      payload = { "warden.user.user.key" => nil }
+      expect(described_class.signed_in?(payload)).to be false
+    end
+  end
+
+  describe ".meta_payload" do
+    it "returns the meta hash" do
+      payload = { "meta" => { "course_id" => "42" } }
+      expect(described_class.meta_payload(payload)).to eq("course_id" => "42")
+    end
+
+    it "returns nil when meta is absent" do
+      expect(described_class.meta_payload({})).to be_nil
+    end
+
+    it "handles symbol keys" do
+      payload = { meta: { course_id: "42" } }
+      expect(described_class.meta_payload(payload)).to eq(course_id: "42")
+    end
+  end
+
+  describe ".fetch_value" do
+    it "fetches with string key" do
+      expect(described_class.fetch_value({ "foo" => "bar" }, :foo)).to eq("bar")
+    end
+
+    it "fetches with symbol key" do
+      expect(described_class.fetch_value({ foo: "bar" }, :foo)).to eq("bar")
+    end
+
+    it "prefers string key over symbol key" do
+      expect(described_class.fetch_value({ "foo" => "string", foo: "symbol" }, :foo)).to eq("string")
+    end
+
+    it "returns nil when key is absent" do
+      expect(described_class.fetch_value({}, :missing)).to be_nil
+    end
+
+    it "returns nil for nil" do
+      expect(described_class.fetch_value(nil, :foo)).to be_nil
+    end
+
+    it "returns nil for objects not responding to []" do
+      obj = Object.new
+      expect(described_class.fetch_value(obj, :foo)).to be_nil
+    end
+
+    it "returns nil when KeyError is raised" do
+      obj = double("weird")
+      allow(obj).to receive(:[]).and_raise(KeyError)
+      expect(described_class.fetch_value(obj, :foo)).to be_nil
+    end
+  end
+
+  describe ".presence" do
+    it "returns the value for a non-empty string" do
+      expect(described_class.presence("hello")).to eq("hello")
+    end
+
+    it "returns nil for nil" do
+      expect(described_class.presence(nil)).to be_nil
+    end
+
+    it "returns nil for empty string" do
+      expect(described_class.presence("")).to be_nil
+    end
+
+    it "returns nil for empty array" do
+      expect(described_class.presence([])).to be_nil
+    end
+
+    it "returns the value for a populated array" do
+      expect(described_class.presence([[1], "salt"])).to eq([[1], "salt"])
+    end
+  end
+end

--- a/spec/rels_session/session_meta_spec.rb
+++ b/spec/rels_session/session_meta_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe RelsSession::SessionMeta do
+  let(:valid_attrs) do
+    {
+      ip: "192.168.1.1",
+      browser: nil,
+      os: nil,
+      app_version: nil,
+      device_name: nil,
+      device_type: nil,
+      installation_id: nil,
+      course_id: nil,
+      client_platform: nil,
+      public_session_id: "abc123",
+      session_key_type: :cookie,
+      created_at: nil,
+      updated_at: Time.now
+    }
+  end
+
+  describe "required attributes" do
+    it "builds with minimum required attrs" do
+      meta = described_class.new(valid_attrs)
+      expect(meta.ip).to eq("192.168.1.1")
+      expect(meta.public_session_id).to eq("abc123")
+      expect(meta.session_key_type).to eq(:cookie)
+      expect(meta.updated_at).to be_a(Time)
+    end
+
+    it "raises Dry::Struct::Error when ip is missing" do
+      expect { described_class.new(valid_attrs.except(:ip)) }.to raise_error(Dry::Struct::Error)
+    end
+
+    it "raises Dry::Struct::Error when public_session_id is missing" do
+      expect { described_class.new(valid_attrs.except(:public_session_id)) }.to raise_error(Dry::Struct::Error)
+    end
+
+    it "raises Dry::Struct::Error when session_key_type is missing" do
+      expect { described_class.new(valid_attrs.except(:session_key_type)) }.to raise_error(Dry::Struct::Error)
+    end
+
+    it "raises Dry::Struct::Error when updated_at is missing" do
+      expect { described_class.new(valid_attrs.except(:updated_at)) }.to raise_error(Dry::Struct::Error)
+    end
+  end
+
+  describe "optional attributes" do
+    it "allows nil for browser" do
+      meta = described_class.new(valid_attrs.merge(browser: nil))
+      expect(meta.browser).to be_nil
+    end
+
+    it "allows nil for os" do
+      meta = described_class.new(valid_attrs.merge(os: nil))
+      expect(meta.os).to be_nil
+    end
+
+    it "allows nil for app_version" do
+      meta = described_class.new(valid_attrs.merge(app_version: nil))
+      expect(meta.app_version).to be_nil
+    end
+
+    it "allows nil for device_name" do
+      meta = described_class.new(valid_attrs.merge(device_name: nil))
+      expect(meta.device_name).to be_nil
+    end
+
+    it "allows nil for device_type" do
+      meta = described_class.new(valid_attrs.merge(device_type: nil))
+      expect(meta.device_type).to be_nil
+    end
+
+    it "allows nil for installation_id" do
+      meta = described_class.new(valid_attrs.merge(installation_id: nil))
+      expect(meta.installation_id).to be_nil
+    end
+
+    it "allows nil for course_id" do
+      meta = described_class.new(valid_attrs.merge(course_id: nil))
+      expect(meta.course_id).to be_nil
+    end
+
+    it "allows nil for client_platform" do
+      meta = described_class.new(valid_attrs.merge(client_platform: nil))
+      expect(meta.client_platform).to be_nil
+    end
+
+    it "allows nil for created_at" do
+      meta = described_class.new(valid_attrs.merge(created_at: nil))
+      expect(meta.created_at).to be_nil
+    end
+  end
+
+  describe "type coercion" do
+    it "coerces public_session_id to string" do
+      meta = described_class.new(valid_attrs.merge(public_session_id: :a_symbol))
+      expect(meta.public_session_id).to eq("a_symbol")
+    end
+
+    it "coerces session_key_type to symbol" do
+      meta = described_class.new(valid_attrs.merge(session_key_type: "token"))
+      expect(meta.session_key_type).to eq(:token)
+    end
+
+    it "raises error for invalid session_key_type" do
+      expect { described_class.new(valid_attrs.merge(session_key_type: :invalid)) }.to raise_error(Dry::Struct::Error)
+    end
+
+    it "coerces course_id to string" do
+      meta = described_class.new(valid_attrs.merge(course_id: 123))
+      expect(meta.course_id).to eq("123")
+    end
+
+    it "coerces updated_at from string" do
+      time = Time.now
+      meta = described_class.new(valid_attrs.merge(updated_at: time.to_s))
+      expect(meta.updated_at).to be_a(Time)
+    end
+
+    it "coerces created_at from string" do
+      time = Time.now
+      meta = described_class.new(valid_attrs.merge(created_at: time.to_s))
+      expect(meta.created_at).to be_a(Time)
+    end
+  end
+end

--- a/spec/rels_session/session_store_spec.rb
+++ b/spec/rels_session/session_store_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RelsSession::SessionStore do
     it "round-trips sessions using the Oj serializer" do
       RelsSession.serializer = :oj
       write_session
-      expect(find_session.last).to eq("test"=> "figs")
+      expect(find_session.last).to eq("test" => "figs")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe RelsSession::SessionStore do
 
         session = find_session.last
         expect(session).to eq(
-          "test"=> "figs"
+          "test" => "figs"
         )
       end
     end
@@ -136,8 +136,8 @@ RSpec.describe RelsSession::SessionStore do
 
         expect(result).to eq(
           [
-            { "test"=> "figs" },
-            { "another"=> "value" }
+            { "test" => "figs" },
+            { "another" => "value" }
           ]
         )
       end
@@ -190,8 +190,8 @@ RSpec.describe RelsSession::SessionStore do
 
       expect(result).to eq(
         [
-          { "test"=> "figs" },
-          { "another"=> "value" }
+          { "test" => "figs" },
+          { "another" => "value" }
         ]
       )
     end

--- a/spec/rels_session/sessions_manager_spec.rb
+++ b/spec/rels_session/sessions_manager_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe RelsSession::SessionsManager do
       expect(described_active_sessions.map(&:public_session_id))
         .to include(active_session_meta[:public_session_id])
     end
-
   end
 
   describe ".record_authenticated_request" do

--- a/spec/rels_session/stats_spec.rb
+++ b/spec/rels_session/stats_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe RelsSession::Stats do
   describe "#reconcile!" do
     it "recomputes totals from actual session keys" do
       redis_double = instance_double("Redis")
-      allow(redis_double).to receive(:scan).and_return(["0", ["#{RelsSession.namespace}:2:abc", "#{RelsSession.namespace}:2:def"]])
+      allow(redis_double).to receive(:scan).and_return(["0",
+                                                        ["#{RelsSession.namespace}:2:abc",
+                                                         "#{RelsSession.namespace}:2:def"]])
       allow(redis_double).to receive(:multi).and_yield(double(set: true))
       allow(redis_double).to receive(:get).and_return("2", Time.now.to_i.to_s)
       proxy = Object.new


### PR DESCRIPTION
- Bump version constraint from '< 3' to '< 4' in gemspec
- Splat pool_options as kwargs for v3 keyword-args constructor